### PR TITLE
docs: Improve the minimal supported version for Scala JS and Scala Na…

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 To include it in your SBT project from maven central:
 
 ```scala
-"com.indoorvivants" %% "scala-uri" % "4.1.0"
+"com.indoorvivants" %% "scala-uri" % "4.2.0"
 ```
 
 ## Migration Guides
@@ -893,7 +893,7 @@ The type class instances exist in the companion objects for these types.
 Release builds are available in maven central. For SBT users just add the following dependency:
 
 ```scala
-"com.indoorvivants" %% "scala-uri" % "4.1.0"
+"com.indoorvivants" %% "scala-uri" % "4.2.0"
 ```
 
 For maven users you should use (for 2.13.x):
@@ -902,7 +902,7 @@ For maven users you should use (for 2.13.x):
 <dependency>
     <groupId>com.indoorvivants</groupId>
     <artifactId>scala-uri_2.13</artifactId>
-    <version>4.1.0</version>
+    <version>4.2.0</version>
 </dependency>
 ```
 
@@ -914,6 +914,8 @@ Contributions to `scala-uri` are always welcome. Check out the [Contributing Gui
 
 ## 3.x.x to 4.x.x
 
+ * Add Scala Native support since version 4.2.0
+ * Minimal supported version for Scala JS under namespace `com.indoorvivants` starts from version 4.1.0
  * Scala 3 support has been added. Scala 2.13 and 2.12 support remain
  * *Binary Incompatibility*: [4765b4e](https://github.com/lemonlabsuk/scala-uri/commit/4765b4e6714a87d53ba0ae9bf58810e1b8be63d5#diff-e33d822268175cadb9ff5e2057fac2042db550f251da28d834f13b7bb44cf09aL45)
    removed a single `UriConfig.copy()` overload.


### PR DESCRIPTION
Hi Anton,

I'm trying to add `scala-uri:4.1.0` as README shows, but I failed with 

```
Resolution failed for 1 modules:
--------------------------------------------
  com.indoorvivants:scala-uri_native0.5_3:4.1.0
        Not an internal Mill module: com.indoorvivants:scala-uri_native0.5_3:4.1.0
        not found: /home/lqhuang/.ivy2/local/com.indoorvivants/scala-uri_native0.5_3/4.1.0/ivys/ivy.xml
        not found: https://repo1.maven.org/maven2/com/indoorvivants/scala-uri_native0.5_3/4.1.0/scala-uri_native0.5_3-4.1.0.pom
```

I checked maven, I found the minimal version for Scala Native is 4.2.0.

So I'm opening this PR to update the version tag and try to improve the migration guide for 4.x.x

Version checking sources:

- https://central.sonatype.com/artifact/com.indoorvivants/scala-uri_native0.5_3
- https://central.sonatype.com/artifact/com.indoorvivants/scala-uri_sjs1_3

Thank you for forking and maintaining `scala-uri`!